### PR TITLE
Bump to 0.7.0.1 and modernize specs

### DIFF
--- a/facetimehd-firmware.spec
+++ b/facetimehd-firmware.spec
@@ -17,8 +17,8 @@ License:        GPL-2.0-only
 URL:            %{forgeurl}
 Source:         %{forgesource}
 
-BuildRequires:  bash
-BuildRequires:  coreutils
+BuildArch:      noarch
+
 BuildRequires:  curl
 BuildRequires:  cpio
 BuildRequires:  gzip
@@ -38,10 +38,13 @@ FacetimeHD firmware download and extraction tool
 %make_install FW_DIR_BASE="%{_prefix}/lib/firmware" FW_DIR="%{_prefix}/lib/firmware/%{srcname}" 
 
 %files
-#%license LICENSE
-#%doc README.md
+%license LICENSE
 %{_prefix}/lib/firmware/facetimehd/firmware.bin
 
 %changelog
+* Sun Apr 19 2026 Jon Mulder <jon.e.mulder@gmail.com> - 1.0.0-1
+- Mark package noarch; drop redundant bash/coreutils BuildRequires
+- Ship upstream LICENSE via %%license macro
+
 * Tue Mar 19 2024 Jon Mulder <jon.e.mulder@gmail.com>
 - Updated upstream build and spec file to build

--- a/facetimehd-kmod.spec
+++ b/facetimehd-kmod.spec
@@ -13,14 +13,13 @@
 %global kmodname facetimehd
 
 %global forgeurl https://github.com/patjak/%{srcname}
-%global tag 0.6.13
+%global tag 0.7.0.1
 %forgemeta
 
 Name:       %{srcname}-kmod
 Version:    %{tag}
 Release:    1%{?dist}
 Summary:    Kernel module for FacetimeHD webcam
-Group:      System Environment/Kernel
 License:    GPL-2.0-only
 URL:        %{forgeurl}
 Source:     %{forgesource}
@@ -53,7 +52,7 @@ Macbooks.
 %{?kmodtool_check}
 
 # print kmodtool output for debugging purposes:
-kmodtool --target %{_target_cpu}  --repo rpmfusion --kmodname %{kmodname} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null | grep -v kmod-common
+kmodtool --target %{_target_cpu} --kmodname %{kmodname} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null | grep -v kmod-common
 
 %forgeautosetup
 
@@ -86,6 +85,10 @@ chmod 0755 $RPM_BUILD_ROOT%{kmodinstdir_prefix}*%{kmodinstdir_postfix}/* || :
 %{?akmod_install}
 
 %changelog
+* Sun Apr 19 2026 Jon Mulder <jon.e.mulder@gmail.com> - 0.7.0.1-1
+- Update to 0.7.0.1 release (fixes build against kernel >= 7.0)
+- Drop deprecated Group tag and stale --repo rpmfusion debug flag
+
 * Mon Mar 17 2025 Jon Mulder <jon.e.mulder@gmail.com>
 - Update to 0.6.13 release
 

--- a/facetimehd.spec
+++ b/facetimehd.spec
@@ -5,17 +5,18 @@
 %global srcname facetimehd
 
 %global forgeurl https://github.com/patjak/%{srcname}
-%global tag 0.6.13
+%global tag 0.7.0.1
 %forgemeta
 
 Name:       facetimehd
 Version:    %{tag}
 Release:    1%{?dist}
 Summary:    Kernel module for FacetimeHD webcam
-Group:      System Environment/Kernel
 License:    GPL-2.0-only
 URL:        %{forgeurl}
 Source:     %{forgesource}
+
+BuildArch:  noarch
 
 Provides: %{name}-kmod-common = %{version}
 Requires: %{name}-kmod >= %{version}
@@ -30,33 +31,21 @@ Macbooks.
 %forgeautosetup
 
 %install
-if [ "$RPM_BUILD_ROOT" != "/" ]; then
-	rm -rf $RPM_BUILD_ROOT
-fi
-
-mkdir -p $RPM_BUILD_ROOT/usr/src/%{name}-%{version}/
-cp -rf %{_builddir}/%{srcname}-%{version}/* $RPM_BUILD_ROOT/usr/src/%{name}-%{version}
-
-mkdir -p $RPM_BUILD_ROOT/usr/share/doc/%{name}/
-cp %{_builddir}/%{srcname}-%{version}/README.md $RPM_BUILD_ROOT/usr/share/doc/%{name}/
-
 mkdir -p $RPM_BUILD_ROOT/etc/modules-load.d/
 echo -e "# Load facetimehd.ko at boot\nfacetimehd" > $RPM_BUILD_ROOT/etc/modules-load.d/facetimehd.conf
 
-%clean
-if [ "$RPM_BUILD_ROOT" != "/" ]; then
-	rm -rf $RPM_BUILD_ROOT
-fi
-
 %files
-#%doc openrgb-dkms-main/README.md
-#%license openrgb-dkms-main/LICENSE
-%defattr(-,root,root)
+%license LICENSE
+%doc README.md
 %config /etc/modules-load.d/facetimehd.conf
-/usr/src/%{name}-%{version}/
-/usr/share/doc/%{name}/
 
 %changelog
+* Sun Apr 19 2026 Jon Mulder <jon.e.mulder@gmail.com> - 0.7.0.1-1
+- Update to 0.7.0.1 release (fixes build against kernel >= 7.0)
+- Package upstream LICENSE and README.md via %%license/%%doc macros
+- Mark package noarch; drop deprecated Group tag and legacy %%clean cruft
+- Drop unused DKMS source tree under /usr/src
+
 * Mon Mar 17 2025 Jon Mulder <jon.e.mulder@gmail.com>
 - Update to 0.6.13 release
 

--- a/facetimehd.spec
+++ b/facetimehd.spec
@@ -31,13 +31,16 @@ Macbooks.
 %forgeautosetup
 
 %install
-mkdir -p $RPM_BUILD_ROOT/etc/modules-load.d/
-echo -e "# Load facetimehd.ko at boot\nfacetimehd" > $RPM_BUILD_ROOT/etc/modules-load.d/facetimehd.conf
+install -d -m 0755 %{buildroot}%{_sysconfdir}/modules-load.d
+install -p -m 0644 /dev/stdin %{buildroot}%{_sysconfdir}/modules-load.d/facetimehd.conf <<'EOF'
+# Load facetimehd.ko at boot
+facetimehd
+EOF
 
 %files
 %license LICENSE
 %doc README.md
-%config /etc/modules-load.d/facetimehd.conf
+%config(noreplace) %{_sysconfdir}/modules-load.d/facetimehd.conf
 
 %changelog
 * Sun Apr 19 2026 Jon Mulder <jon.e.mulder@gmail.com> - 0.7.0.1-1


### PR DESCRIPTION
Fixes build failures against Linux kernel >= 7.0 by updating the
facetimehd and facetimehd-kmod packages to upstream release 0.7.0.1,
which omits the removed wait_prepare/wait_finish vb2_ops callbacks on
newer kernels (patjak/facetimehd PR #320).

Also cleans up legacy spec cruft:

- facetimehd-kmod.spec: drop deprecated Group tag and stale
  --repo rpmfusion flag from the debug kmodtool invocation.
- facetimehd.spec: mark noarch, drop DKMS-vestige /usr/src copy and
  manual README install, replace dead commented-out license/doc lines
  with proper %license/%doc macros, remove obsolete %clean section and
  $RPM_BUILD_ROOT guards.
- facetimehd-firmware.spec: mark noarch, drop redundant bash/coreutils
  BuildRequires, ship upstream LICENSE via %license.

https://claude.ai/code/session_01HjrTdX849qGTGM9yBU3LUr