### PR TITLE
fix(spec): background %post akmods call to match Fedora akmod macro

### DIFF
--- a/facetimehd-kmod.spec
+++ b/facetimehd-kmod.spec
@@ -18,7 +18,7 @@
 
 Name:       %{srcname}-kmod
 Version:    %{tag}
-Release:    1%{?dist}
+Release:    2%{?dist}
 Summary:    Kernel module for FacetimeHD webcam
 License:    GPL-2.0-only
 URL:        %{forgeurl}
@@ -84,7 +84,13 @@ done
 chmod 0755 $RPM_BUILD_ROOT%{kmodinstdir_prefix}*%{kmodinstdir_postfix}/* || :
 %{?akmod_install}
 
+%post -n akmod-%{kmodname} -p /bin/bash
+/usr/sbin/akmods -q --kernels $(uname -r) --kmod %{kmodname} >/dev/null 2>&1 &
+
 %changelog
+* Sun Apr 19 2026 Jon Mulder <jon.e.mulder@gmail.com> - 0.7.0.1-2
+- async %post to avoid tripping akmodsbuild root guard in OCI builds
+
 * Sun Apr 19 2026 Jon Mulder <jon.e.mulder@gmail.com> - 0.7.0.1-1
 - Update to 0.7.0.1 release (fixes build against kernel >= 7.0)
 - Drop deprecated Group tag and stale --repo rpmfusion debug flag


### PR DESCRIPTION
## Summary

- Add an explicit `%post -n akmod-%{kmodname}` scriptlet in `facetimehd-kmod.spec` that backgrounds the `akmods` call with a trailing `&`, matching Fedora's standard akmod `%post` macro.
- Bump `Release` from `1` to `2` and add a `%changelog` entry.

## Why

The synchronous `akmods` invocation trips `akmodsbuild`'s root guard during OCI image builds (observed in `mulderje/ublue-oldair` PR #24, run `24646175697`), killing `dnf install`. Running the call in the background — as the upstream Fedora akmod macro does — sidesteps the guard and lets the install complete.

## Scriptlet

```spec
%post -n akmod-%{kmodname} -p /bin/bash
/usr/sbin/akmods -q --kernels $(uname -r) --kmod %{kmodname} >/dev/null 2>&1 &
```

## Test plan

- [ ] `rpmbuild -bs facetimehd-kmod.spec` succeeds
- [ ] `rpmlint facetimehd-kmod.spec` shows no new errors
- [ ] `dnf install akmod-facetimehd` completes inside an OCI build (e.g. `mulderje/ublue-oldair`) without the `akmodsbuild` root-guard failure
- [ ] Module still rebuilds on first boot after install on a running system

## Notes

- The repo does not ship a separate `akmod-facetimehd.spec`; the akmod subpackage is generated via `kmodtool` expansion in `facetimehd-kmod.spec`, so the override `%post` is appended there.
- `rpmlint` was not available in the development sandbox, so please run it locally before merging.
- Developed on branch `claude/fix-async-post-scriptlet-4xIXm` per session-level branch instructions (rather than `fix/async-post-scriptlet`).
