### PR TITLE
[SCRATCH] test patched kmodtool-1.2-4 from koji (dist-git PR #18)

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -69,6 +69,13 @@ jobs:
     targets:
       - fedora-all-x86_64
     enable_net: true
+    # SCRATCH TEST (Fedora dist-git kmodtool PR #18):
+    # Pull patched kmodtool-1.2-4.fc45 from koji scratch task so the
+    # kmodtool-generated %post for akmod-facetimehd no longer trips
+    # akmodsbuild's "-w /" root guard in OCI container layering.
+    # Remove this block once kmodtool-1.2-4 lands in stable Fedora repos.
+    additional_packages:
+      - https://kojipkgs.fedoraproject.org//work/tasks/2312/144642312/kmodtool-1.2-4.fc45.noarch.rpm
 
   # Merges to main publish to the official Copr that ublue-oldair and
   # downstream installs consume. Matches the PR target matrix so every


### PR DESCRIPTION
## SCRATCH TEST — DO NOT MERGE

Validation vehicle for the akmod `%post` fix proposed in [Fedora dist-git kmodtool PR #18](https://src.fedoraproject.org/rpms/kmodtool/pull-request/18). The patched `kmodtool-1.2-4.fc45` isn't in stable Fedora repos yet — it only exists as a koji scratch build — so this PR wires the PR-trigger Copr job to pull the RPM directly from koji via Packit's `additional_packages`.

## What it does

Adds `additional_packages:` to the `pull_request` → `mulderje/facetimehd-kmod-pr` Copr job in `.packit.yaml`:

```yaml
additional_packages:
  - https://kojipkgs.fedoraproject.org//work/tasks/2312/144642312/kmodtool-1.2-4.fc45.noarch.rpm
```

Copr's mock chroot installs that URL-based RPM *before* `rpmbuild -bb` runs, so `%{expand:%(kmodtool …)}` invokes the patched template and every akmod `%post` in this PR's build reflects the fix.

Scope: **only the PR job** is modified. The `commit`-trigger job (which publishes to the user-facing `mulderje/facetimehd-kmod` Copr) stays on stock kmodtool until PR #18 lands in Fedora proper.

## Test plan

- [ ] Packit picks up this PR and submits builds to `mulderje/facetimehd-kmod-pr`
- [ ] Build log shows `kmodtool-1.2-4.fc45.noarch` installed in the buildroot (not the stock Fedora version)
- [ ] Resulting `akmod-facetimehd` RPM's `%post` matches the PR #18 patched template (extract with `rpm -qp --scripts`)
- [ ] Companion PR on `mulderje/ublue-oldair` (TBD in another session) installs this PR's `akmod-facetimehd` RPM and completes image build without the "Not to be used as root" error

## If the koji URL 404s

Koji scratch tasks are garbage-collected after ~2 weeks. If this PR sits that long without merging the real dist-git fix, the URL will start returning 404 and Copr builds will fail at dnf install. Either refresh the URL with a newer scratch task or wait for the real fix to land.

## Cleanup

Revert the single commit once `kmodtool-1.2-4` (or the final NVR that ships from PR #18) is available in Fedora stable repos.

https://claude.ai/code/session_01HjrTdX849qGTGM9yBU3LUr